### PR TITLE
Simplify the 'slugify' filter, which was simply not working

### DIFF
--- a/lib/liquidoc.rb
+++ b/lib/liquidoc.rb
@@ -646,34 +646,14 @@ module CustomFilters
     end
   end
 
-  # From Slate Studio's fork of Locomotive CMS engine
-  # https://github.com/slate-studio/engine/blob/master/lib/locomotive/core_ext.rb
-  def slugify(options = {})
-    options = { :sep => '_', :without_extension => false, :downcase => false, :underscore => false }.merge(options)
-    # replace accented chars with ther ascii equivalents
-    s = ActiveSupport::Inflector.transliterate(self).to_s
-    # No more than one slash in a row
-    s.gsub!(/(\/[\/]+)/, '/')
-    # Remove leading or trailing space
-    s.strip!
-    # Remove leading or trailing slash
-    s.gsub!(/(^[\/]+)|([\/]+$)/, '')
-    # Remove extensions
-    s.gsub!(/(\.[a-zA-Z]{2,})/, '') if options[:without_extension]
+  def slugify input
     # Downcase
-    s.downcase! if options[:downcase]
     # Turn unwanted chars into the seperator
-    s.gsub!(/[^a-zA-Z0-9\-_\+\/]+/i, options[:sep])
-    # Underscore
-    s.gsub!(/[\-]/i, '_') if options[:underscore]
+    s = input.to_s.downcase
+    s.gsub!(/[^a-zA-Z0-9\-_\+\/]+/i, "-")
     s
   end
-  def slugify!(options = {})
-    replace(self.slugify(options))
-  end
-  def parameterize!(sep = '_')
-    replace(self.parameterize(sep))
-  end
+
 end
 
 # register custom Liquid filters

--- a/lib/liquidoc/version.rb
+++ b/lib/liquidoc/version.rb
@@ -1,3 +1,3 @@
 module Liquidoc
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION
I removed the copyright notice because now I'm basically only taking one line that I think nobody would argue is a unique work, and I'd rather not sully the far cooler slugify method in the original

* Bumps version to 0.5.4